### PR TITLE
Fix: Fixing the permission on id_rsa key.

### DIFF
--- a/rootfs/start.sh
+++ b/rootfs/start.sh
@@ -5,6 +5,7 @@ gitSecret="/root/.ssh/id_rsa"
 mkdir -p /root/.ssh
 if [ -n "$GIT_SYNC_PRIVATE_KEY" ]; then
     echo "$GIT_SYNC_PRIVATE_KEY" > "$gitSecret"
+    chmod 0600 "$gitSecret"
 fi
 
 gitHosts="/root/.ssh/known_hosts"


### PR DESCRIPTION
If the key is passed by the docker environment, it's got the wrong permission and the clone doesn't happen.

`-----END OPENSSH PRIVATE KEY-----'                                                                                                                    
Cloning into '/git'...
^C@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@         WARNING: UNPROTECTED PRIVATE KEY FILE!          @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
Permissions 0644 for '/root/.ssh/id_rsa' are too open.
It is required that your private key files are NOT accessible by others.
This private key will be ignored.
Load key "/root/.ssh/id_rsa": bad permissions
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
`